### PR TITLE
Add Ativo model and view tests

### DIFF
--- a/estoque/tests.py
+++ b/estoque/tests.py
@@ -1,3 +1,26 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Ativo
+
+
+class AtivoModelTests(TestCase):
+    def test_ativo_str_representation(self):
+        ativo = Ativo.objects.create(
+            tipo="Computador",
+            nome="Dell",
+            numero_patrimonio="ABC123",
+            status="disponível",
+        )
+        self.assertEqual(str(ativo), "Computador - Dell (ABC123)")
+
+
+class AtivoListViewTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="testpass")
+
+    def test_list_view_authenticated(self):
+        self.client.login(username="tester", password="testpass")
+        response = self.client.get(reverse("ativo_list"))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- create tests for `Ativo` model string representation
- ensure the list view is reachable for logged-in users

## Testing
- `python3 manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68433dbc91bc8323b388aea9e7d3ead4